### PR TITLE
Dev 1.0.8 Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-favicons",
-  "version": "1.0.2",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webpack html favicon",
     "webpack favicons"
   ],
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Webpack plugin to generate favicons for devices and browsers",
   "repository": "drolsen/webpack-favicons",
   "bugs": {
@@ -17,8 +17,10 @@
   "author": "Devin R. Olsen <devin@devinrolsen.com> (http://devinrolsen.com)",
   "license": "MIT",
   "scripts": {
-    "test": "npm run basic-test && npm run ava-test",
-    "basic-test": "webpack --config ./test/test.config.js --mode production",
+    "test": "npm run basic-test && npm run nested-test && npm run public-test && npm run ava-test",
+    "basic-test": "webpack --config ./test/basic.config.js --mode production",
+    "nested-test": "webpack --config ./test/nested.config.js --mode production",
+    "public-test": "webpack --config ./test/public-path.config.js --mode production",
     "ava-test": "ava ./test/ava.test.js"
   },
   "engines": {

--- a/test/ava.test.js
+++ b/test/ava.test.js
@@ -29,14 +29,27 @@ test('insert', t => {
   }
 });
 
-
-test('manifest', t => {
+test('nested', t => {
   let hasFile = false;
-    if (fs.existsSync(path.resolve(__dirname, '../dist/assets/manifest.json'))){
+    if (fs.existsSync(path.resolve(__dirname, '../dist/nested/assets/favicon.ico'))){
       hasFile = true;
     }
 
   if (hasFile) {
+    t.pass();
+  } else {
+    t.fail();
+  }
+});
+
+test('publicPath', t => {
+  let insert = false;
+  const testData = fs.readFileSync(path.resolve(__dirname, '../dist/public/test.html'), 'utf8');
+  if (testData.toString().indexOf('href="/~media/') !== -1) {
+    insert = true;
+  }
+
+  if (insert) {
     t.pass();
   } else {
     t.fail();

--- a/test/basic.config.js
+++ b/test/basic.config.js
@@ -7,7 +7,7 @@ module.exports = {
   entry: path.resolve(__dirname, 'test.js'),
   output: {
     path: path.resolve(__dirname, '../dist'), 
-    filename: '../dist/test.js',
+    filename: 'test.js',
     pathinfo: false
   },
   module: {
@@ -27,7 +27,9 @@ module.exports = {
     minimize: false
   },
   plugins: [
-    new CleanWebpackPlugin(),
+    new CleanWebpackPlugin({
+      'cleanOnceBeforeBuildPatterns': [path.resolve('./dist/')]
+    }),
     new HtmlWebpackPlugin({
       'title': 'Basic Test',
       'template': './test/test.html',
@@ -41,16 +43,16 @@ module.exports = {
       'background': '#000',
       'theme_color': '#000',
       'icons': {
-        'android': true,
-        'appleIcon': true,
-        'appleStartup': true,
-        'coast': true,
+        'android': false,
+        'appleIcon': false,
+        'appleStartup': false,
+        'coast': false,
         'favicons': true,
-        'firefox': true,
-        'opengraph': true,
-        'twitter': true,
-        'yandex': true,
-        'windows': true
+        'firefox': false,
+        'opengraph': false,
+        'twitter': false,
+        'yandex': false,
+        'windows': false
       }
     })  
   ]

--- a/test/nested.config.js
+++ b/test/nested.config.js
@@ -1,0 +1,60 @@
+const WebpackFavicons = require('../index.js');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+
+module.exports = {
+  entry: path.resolve(__dirname, 'test.js'),
+  output: {
+    path: path.resolve(__dirname, '../dist/nested'), 
+    filename: 'test.js',
+    pathinfo: false
+  },
+  module: {
+    rules: [{
+      'test': /\.html$/,
+      'exclude': /node_modules/,
+      'include': [
+        path.resolve(__dirname, 'test.html')
+      ],
+      'use': {
+        'loader': 'html-loader', // (see: https://www.npmjs.com/package/html-loader)
+        'options': { 'minimize': false }
+      }
+    }]
+  },
+  optimization: {
+    minimize: false
+  },
+  plugins: [
+    new CleanWebpackPlugin({
+      'cleanOnceBeforeBuildPatterns': [path.resolve('./dist/nested')]
+    }),
+    new HtmlWebpackPlugin({
+      'title': 'Basic Test',
+      'template': './test/test.html',
+      'filename': './test.html',
+      'minify': false
+    }),
+    new WebpackFavicons({
+      'src': 'assets/favicon.svg',
+      'path': 'assets/',
+      'scope': 'resources/',
+      'background': '#000',
+      'theme_color': '#000',
+      'icons': {
+        'android': false,
+        'appleIcon': false,
+        'appleStartup': false,
+        'coast': false,
+        'favicons': true,
+        'firefox': false,
+        'opengraph': false,
+        'twitter': false,
+        'yandex': false,
+        'windows': false
+      }
+    })  
+  ]
+};
+

--- a/test/public-path.config.js
+++ b/test/public-path.config.js
@@ -1,0 +1,61 @@
+const WebpackFavicons = require('../index.js');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+
+module.exports = {
+  entry: path.resolve(__dirname, 'test.js'),
+  output: {
+    path: path.resolve(__dirname, '../dist/public'), 
+    publicPath: '/~media/',
+    filename: 'test.js',
+    pathinfo: false
+  },
+  module: {
+    rules: [{
+      'test': /\.html$/,
+      'exclude': /node_modules/,
+      'include': [
+        path.resolve(__dirname, 'test.html')
+      ],
+      'use': {
+        'loader': 'html-loader', // (see: https://www.npmjs.com/package/html-loader)
+        'options': { 'minimize': false }
+      }
+    }]
+  },
+  optimization: {
+    minimize: false
+  },
+  plugins: [
+    new CleanWebpackPlugin({
+      'cleanOnceBeforeBuildPatterns': [path.resolve('./dist/public')]
+    }),
+    new HtmlWebpackPlugin({
+      'title': 'Basic Test',
+      'template': './test/test.html',
+      'filename': './test.html',
+      'minify': false
+    }),
+    new WebpackFavicons({
+      'src': 'assets/favicon.svg',
+      'path': 'assets/',
+      'scope': 'resources/',
+      'background': '#000',
+      'theme_color': '#000',
+      'icons': {
+        'android': false,
+        'appleIcon': false,
+        'appleStartup': false,
+        'coast': false,
+        'favicons': true,
+        'firefox': false,
+        'opengraph': false,
+        'twitter': false,
+        'yandex': false,
+        'windows': false
+      }
+    })  
+  ]
+};
+

--- a/test/test.html
+++ b/test/test.html
@@ -6,6 +6,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body>
-  	<script src="test.js"></script>
   </body>
 </html>


### PR DESCRIPTION
- Updates processAssets tap type to tapPromise
- Move favicon class call into processAssets as a returned promise to ensure consistent HTML source.
- Fixing missing recursive option on folder buildout #8 
- Fixes missing public path in favicon's generated HTML by manual regex replace. #7 