### PR TITLE
Update `favicons` to more recent version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "webpack-cli": "4.9.1"
   },
   "dependencies": {
-    "favicons": "7.0.0-beta.1"
+    "favicons": "7.1.2"
   }
 }


### PR DESCRIPTION
This updates `favicons` to version 7.1.2 which uses the patched version of `xml2js` and `sharp` that fixed minor security vulnerabilities.

Fixes https://github.com/drolsen/webpack-favicons/issues/22

See
- https://github.com/advisories/GHSA-776f-qx25-q3cc
- https://github.com/advisories/GHSA-gp95-ppv5-3jc5
- https://github.com/itgalaxy/favicons/commit/03741dd345c2d44e2ffed0e0ee082cf5b1e09c35
- https://github.com/itgalaxy/favicons/pull/429