### PR TITLE
Dev 1.5.4 Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - '14.17.0'
+  - '18.17.0'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpack-favicons",
-  "version": "1.5.2",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpack-favicons",
-      "version": "1.5.2",
+      "version": "1.5.4",
       "license": "MIT",
       "dependencies": {
         "favicons": "7.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpack-favicons",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpack-favicons",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "favicons": "7.2.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webpack html favicon",
     "webpack favicons"
   ],
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Webpack plugin to generate favicons for devices and browsers",
   "repository": "drolsen/webpack-favicons",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webpack html favicon",
     "webpack favicons"
   ],
-  "version": "1.5.2",
+  "version": "1.5.4",
   "description": "Webpack plugin to generate favicons for devices and browsers",
   "repository": "drolsen/webpack-favicons",
   "bugs": {

--- a/test/ava.test.js
+++ b/test/ava.test.js
@@ -80,6 +80,9 @@ test('minimal-test (no WebpackFavicons "icon": {} configuration)', t => {
 test('full-test (builds lots of favicon types)', t => {
   let fullTest = true;
 
+  const webmanifestTestData = fs.readFileSync(path.resolve(__dirname, '../dist/full/assets/manifest.webmanifest'), 'utf8');
+  const yandexBrowserManifestTestData = fs.readFileSync(path.resolve(__dirname, '../dist/full/assets/yandex-browser-manifest.json'), 'utf8');
+
   if (!fs.existsSync(path.resolve(__dirname, '../dist/full/assets/android-chrome-144x144.png'))){
     fullTest = false;
   }
@@ -118,7 +121,32 @@ test('full-test (builds lots of favicon types)', t => {
 
   if (!fs.existsSync(path.resolve(__dirname, '../dist/full/assets/yandex-browser-50x50.png'))){
     fullTest = false;
-  }                 
+  } 
+
+  if (!fs.existsSync(path.resolve(__dirname, '../dist/full/assets/browserconfig.xml'))){
+    fullTest = false;
+  } 
+
+  if (!fs.existsSync(path.resolve(__dirname, '../dist/full/assets/manifest.webmanifest'))){
+    fullTest = false;
+  } 
+
+  if (!fs.existsSync(path.resolve(__dirname, '../dist/full/assets/yandex-browser-manifest.json'))){
+    fullTest = false;
+  }   
+
+  if (
+    webmanifestTestData.toString().indexOf('"background_color": "#fff"') === -1
+    || webmanifestTestData.toString().indexOf('"theme_color": "#fff"') === -1
+    || webmanifestTestData.toString().indexOf('"name": "Webpack Favicons"') === -1
+    || webmanifestTestData.toString().indexOf('"description": "Favicon Generator for Webpack 5",') === -1
+  ) {
+    fullTest = false;
+  }
+
+  if (yandexBrowserManifestTestData.toString().indexOf('"color": "#fff"') === -1) {
+    fullTest = false;
+  }
 
   if (fullTest) {
     t.pass();

--- a/test/basic.config.js
+++ b/test/basic.config.js
@@ -6,7 +6,8 @@ const path = require('path');
 module.exports = {
   entry: path.resolve(__dirname, 'test.js'),
   output: {
-    path: path.resolve(__dirname, '../dist/basic'), 
+    path: path.resolve(__dirname, '../dist/basic'),
+    publicPath: '/~media/',     
     filename: 'test.js',
     pathinfo: false
   },
@@ -23,9 +24,18 @@ module.exports = {
       }
     }]
   },
+  devtool: false,
   optimization: {
     minimize: false
   },
+  stats: 'none',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../node_modules/.cache/WebpackFavicons/basic'),
+    buildDependencies: {
+      config: [__filename] // Invalidate cache if config changes
+    },
+  },    
   plugins: [
     new CleanWebpackPlugin({
       'cleanOnceBeforeBuildPatterns': [path.resolve('./dist')]
@@ -34,7 +44,9 @@ module.exports = {
       'title': 'Basic Test',
       'template': './test/test.html',
       'filename': './test.html',
-      'minify': false
+      'minify': false,
+      'cache': true, // Enable cache
+      'parallel': true, // Enable parallel processing if available
     }),
     new WebpackFavicons({
       'src': 'assets/favicon.svg',

--- a/test/callback.config.js
+++ b/test/callback.config.js
@@ -24,15 +24,21 @@ module.exports = {
       }
     }]
   },
+  devtool: false,
   optimization: {
     minimize: false
   },
+  stats: 'none',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../node_modules/.cache/WebpackFavicons/callback'),
+    buildDependencies: {
+      config: [__filename] // Invalidate cache if config changes
+    },
+  },    
   plugins: [
-    new CleanWebpackPlugin({
-      'cleanOnceBeforeBuildPatterns': [path.resolve(__dirname, '../dist/callback')]
-    }),
     new HtmlWebpackPlugin({
-      'title': 'Basic Test',
+      'title': 'Callback Test',
       'template': './test/test.html',
       'filename': './test.html',
       'minify': false

--- a/test/copy.config.js
+++ b/test/copy.config.js
@@ -7,6 +7,7 @@ module.exports = {
   entry: path.resolve(__dirname, 'test.js'),
   output: {
     path: path.resolve(__dirname, '../dist/copy'), 
+    publicPath: '/~media/',    
     filename: 'test.js',
     pathinfo: false
   },
@@ -23,13 +24,19 @@ module.exports = {
       }
     }]
   },
+  devtool: false,
   optimization: {
     minimize: false
   },
+  stats: 'none',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../node_modules/.cache/WebpackFavicons/copy'),
+    buildDependencies: {
+      config: [__filename] // Invalidate cache if config changes
+    },
+  },    
   plugins: [
-    new CleanWebpackPlugin({
-      'cleanOnceBeforeBuildPatterns': [path.resolve('./dist/copy/')]
-    }),
     new CopyPlugin({
       patterns: [
         { from: 'test/test.html', to: './' }

--- a/test/full.config.js
+++ b/test/full.config.js
@@ -24,24 +24,32 @@ module.exports = {
       }
     }]
   },
+  devtool: false,
   optimization: {
     minimize: false
   },
+  stats: 'none',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../node_modules/.cache/WebpackFavicons/full'),
+    buildDependencies: {
+      config: [__filename] // Invalidate cache if config changes
+    },
+  },   
   plugins: [
-    new CleanWebpackPlugin({
-      'cleanOnceBeforeBuildPatterns': [path.resolve(__dirname, '../dist/full')]
-    }),
     new HtmlWebpackPlugin({
-      'title': 'Basic Test',
+      'title': 'Full Test',
       'template': './test/test.html',
       'filename': './test.html',
       'minify': false
     }),
     new WebpackFavicons({
+      'appName': 'Webpack Favicons',
+      'appDescription': 'Favicon Generator for Webpack 5',
       'src': 'assets/favicon.svg',
       'path': 'assets',
-      'background': '#000',
-      'theme_color': '#000',
+      'background': '#fff',
+      'theme_color': '#fff',
       'icons': {
         'android': true,
         'appleIcon': true,

--- a/test/hybridcopy.config.js
+++ b/test/hybridcopy.config.js
@@ -8,6 +8,7 @@ module.exports = {
   entry: path.resolve(__dirname, 'test.js'),
   output: {
     path: path.resolve(__dirname, '../dist/hybrid'), 
+    publicPath: '/~media/',
     filename: 'test.js',
     pathinfo: false
   },
@@ -24,13 +25,19 @@ module.exports = {
       }
     }]
   },
+  devtool: false,
   optimization: {
     minimize: false
   },
+  stats: 'none',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../node_modules/.cache/WebpackFavicons/hybridcopy'),
+    buildDependencies: {
+      config: [__filename] // Invalidate cache if config changes
+    },
+  },    
   plugins: [
-    new CleanWebpackPlugin({
-      'cleanOnceBeforeBuildPatterns': [path.resolve('./dist/hybrid/')]
-    }),
     new CopyPlugin({
       patterns: [
         { from: 'test/test.html', to: './' }

--- a/test/minimal.config.js
+++ b/test/minimal.config.js
@@ -7,6 +7,7 @@ module.exports = {
   entry: path.resolve(__dirname, 'test.js'),
   output: {
     path: path.resolve(__dirname, '../dist/minimal'), 
+    publicPath: '/~media/',    
     filename: 'test.js',
     pathinfo: false
   },
@@ -23,15 +24,21 @@ module.exports = {
       }
     }]
   },
+  devtool: false,
   optimization: {
     minimize: false
   },
+  stats: 'none',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../node_modules/.cache/WebpackFavicons/minimal'),
+    buildDependencies: {
+      config: [__filename] // Invalidate cache if config changes
+    },
+  },    
   plugins: [
-    new CleanWebpackPlugin({
-      'cleanOnceBeforeBuildPatterns': [path.resolve('./dist/minimal')]
-    }),
     new HtmlWebpackPlugin({
-      'title': 'Basic Test',
+      'title': 'Minimal Test',
       'template': './test/test.html',
       'filename': './test.html',
       'minify': false

--- a/test/mixed-path.config.js
+++ b/test/mixed-path.config.js
@@ -24,15 +24,21 @@ module.exports = {
       }
     }]
   },
+  devtool: false,
   optimization: {
     minimize: false
   },
+  stats: 'none',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../node_modules/.cache/WebpackFavicons/mixedPath'),
+    buildDependencies: {
+      config: [__filename] // Invalidate cache if config changes
+    },
+  },    
   plugins: [
-    new CleanWebpackPlugin({
-      'cleanOnceBeforeBuildPatterns': [path.resolve(__dirname, '../dist/mixed')]
-    }),
     new HtmlWebpackPlugin({
-      'title': 'Basic Test',
+      'title': 'Mixed Path Test',
       'template': './test/test.html',
       'filename': './test.html',
       'minify': false

--- a/test/nested.config.js
+++ b/test/nested.config.js
@@ -7,6 +7,7 @@ module.exports = {
   entry: path.resolve(__dirname, 'test.js'),
   output: {
     path: path.resolve(__dirname, '../dist/nested'), 
+    publicPath: '/~media/',    
     filename: 'test.js',
     pathinfo: false
   },
@@ -23,15 +24,21 @@ module.exports = {
       }
     }]
   },
+  devtool: false,
   optimization: {
     minimize: false
   },
+  stats: 'none',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../node_modules/.cache/WebpackFavicons/nested'),
+    buildDependencies: {
+      config: [__filename] // Invalidate cache if config changes
+    },
+  },    
   plugins: [
-    new CleanWebpackPlugin({
-      'cleanOnceBeforeBuildPatterns': [path.resolve('./dist/nested')]
-    }),
     new HtmlWebpackPlugin({
-      'title': 'Basic Test',
+      'title': 'Nested Test',
       'template': './test/test.html',
       'filename': './test.html',
       'minify': false

--- a/test/public-path.config.js
+++ b/test/public-path.config.js
@@ -24,15 +24,21 @@ module.exports = {
       }
     }]
   },
+  devtool: false,
   optimization: {
     minimize: false
   },
+  stats: 'none',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../node_modules/.cache/WebpackFavicons/publicPath'),
+    buildDependencies: {
+      config: [__filename] // Invalidate cache if config changes
+    },
+  },    
   plugins: [
-    new CleanWebpackPlugin({
-      'cleanOnceBeforeBuildPatterns': [path.resolve('./dist/public')]
-    }),
     new HtmlWebpackPlugin({
-      'title': 'Basic Test',
+      'title': 'Public Path Test',
       'template': './test/test.html',
       'filename': './test.html',
       'minify': false


### PR DESCRIPTION
- travis.yml min node version bump from 14.17.0 to 18.17.0
- Webpack Favicons version number bump to 1.5.4
- Refactors plugin's code to be slimmer and more performant
- Removes stats and manifest from AVA unit test webpack configs
- Adds cache to AVA unit test webpack configs speed unit testing up
- Removes CleanWebpackPlugin from all but first AVA unit testing webpack configs
- Expands 'full' unit test to now ensure manifest files are written to disk
- Expands 'full' unit test to review contents of manifest files