### PR TITLE
DevRelease 1.5.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,76 @@ module.exports = {
 
 ---
 
+### Manifest File
+
+Depending on the options.icons you set for your configuration, you may see a manifest browserconfig or yandexManifest file(s) along with the built icons. 
+
+By default all three file's favicon paths are relative, and will need no altering for most situations. 
+However if you have a need to alter the paths for whatever reasson, you can use the following three path pattern option:
+
+Option | Type | Description
+--- | --- | ---
+`manifestPathPattern` | String | Defines a custom path for this file's icon path. Default is `[filename]` which makes relative paths.
+`browserconfigPathPattern` | String | Defines a custom path for this file's icon path. Default is `[filename]` which makes relative paths.
+`yandexManifestIconPattern` | String | Defines a custom path for this file's icon path. Default is `[filename]` which makes relative paths.
+
+```js
+
+// Basic configuration
+
+module.exports = {
+  output: {
+    path: '/dist', 
+    publicPath: '/~media/'
+  }  
+  plugins: [
+    new WebpackFavicons({
+      src: 'assets/favicon.svg',
+      path: 'img',
+      ...
+      icons: {
+        ...
+      },
+      manifesstPathPattern: '/custom/path/[filename]',
+      browserconfigPathPattern: '/custom/path/[filename]',
+      yandexManifestIconPattern: '/custom/path/[filename]'
+    })
+  ]
+};
+```
+
+#### manifest.webmanifest
+```json
+{
+  "src": "/custom/path/android-chrome-36x36.png",
+  "sizes": "36x36",
+  "type": "image/png",
+  "purpose": "any"
+}
+```
+
+#### yandex-browser-manifest.json
+```json
+"layout": {
+  "logo": "/custom/path/yandex-browser-50x50.png",
+  "color": "#fff",
+  "show_title": true
+}
+```
+
+#### browserconfig.xml
+```xml
+<tile>
+  <square70x70logo src="/custsom/path/mstile-70x70.png"/>
+  <square150x150logo src="/custsom/path/mstile-150x150.png"/>
+  <wide310x150logo src="/custsom/path/mstile-310x150.png"/>
+  <square310x310logo src="/custsom/path/mstile-310x310.png"/>
+  <TileColor>#fff</TileColor>
+</tile>
+```
+
+(Please note these options are custom to this plugin are not part of the itgalaxy/favicons module.)
+
 ### Tests
 
 Webpack Favicons comes with a few `test`s.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ module.exports = {
 Depending on the options.icons you set for your configuration, you may see a manifest browserconfig or yandexManifest file(s) along with the built icons. 
 
 By default all three file's favicon paths are relative, and will need no altering for most situations. 
-However if you have a need to alter the paths for whatever reasson, you can use the following three path pattern option:
+However if you have a need to alter the paths (for whatever reason), you can use the following three path pattern options to do so:
 
 Option | Type | Description
 --- | --- | ---

--- a/index.js
+++ b/index.js
@@ -22,24 +22,35 @@ const fixManifestIconSrc = (pattern, file) => {
     }
     file.contents = JSON.stringify(manifest, null, 2);
   } catch (err) {
-    console.log(err);
+    console.error(err);
   }
 
   return file;
 };
 
 const fixBrowserconfigSrc = (pattern, file) => {
-  // Only process if XML, simple regex replace to drop path from src attribute
   try {
     file.contents = file.contents.replace(/src="([^"]+)"/g, (match, src) => {
       return `src="${pattern.replace('[filename]', path.basename(src))}"`;
     });
   } catch (err) {
-    console.log(err);
+    console.error(err);
   }
 
   return file;
-}
+};
+
+const fixYandexManifestIconSrc = (pattern, file) => {
+  try {
+    const manifest = JSON.parse(file.contents);
+    manifest.layout.logo = pattern.replace('[filename]', path.basename(manifest.layout.logo)) // keep only filename
+    file.contents = JSON.stringify(manifest, null, 2);
+  } catch (err) {
+    console.error(err);
+  }
+
+  return file;
+};
 
 class WebpackFavicons {
   constructor(options, callback) {
@@ -68,6 +79,7 @@ class WebpackFavicons {
       icons: { favicons: true },                // Specify which icons to generate
       manifestPathPattern: '[filename]',        // Manifest file's icon path pattern (default is relative)
       browserconfigPathPattern: '[filename]',   // Browserconfig file'ss icon path pattern (default is relative)
+      yandexManifestIconPattern: '[filename]',   // Yandex Manifest file's icon path pattern (default is relative)
       ...options,
     };
 
@@ -128,6 +140,11 @@ class WebpackFavicons {
                   if (file.name === 'browserconfig.xml') {
                     file = fixBrowserconfigSrc(this.options.browserconfigPathPattern, file);
                   }
+
+                  // favicons npm module does not write paths correctly to yandex file, this is their own issue but we can fix it.
+                  if (file.name === 'yandex-browser-manifest.json') {
+                    file = fixYandexManifestIconSrc(this.options.yandexManifestIconPattern, file);
+                  }                  
                 });
               }
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,40 @@ const getAttributes = (markup) =>
 
 const getTagType = (markup) => (markup.includes('meta') ? 'meta' : 'link');
 
+const applyPathPattern = (pattern, file) => {
+  return pattern.replace('[filename]', file.name);
+};
+
+const fixManifestIconSrc = (pattern, file) => {
+  try {
+    const manifest = JSON.parse(file.contents);
+    if (manifest.icons) {
+      manifest.icons = manifest.icons.map(icon => ({
+        ...icon,
+        src: pattern.replace('[filename]', path.basename(icon.src)) // keep only filename
+      }));
+    }
+    file.contents = JSON.stringify(manifest, null, 2);
+  } catch (err) {
+    console.log(err);
+  }
+
+  return file;
+};
+
+const fixBrowserconfigSrc = (pattern, file) => {
+  // Only process if XML, simple regex replace to drop path from src attribute
+  try {
+    file.contents = file.contents.replace(/src="([^"]+)"/g, (match, src) => {
+      return `src="${pattern.replace('[filename]', path.basename(src))}"`;
+    });
+  } catch (err) {
+    console.log(err);
+  }
+
+  return file;
+}
+
 class WebpackFavicons {
   constructor(options, callback) {
     // Setting default options, user options will override
@@ -32,6 +66,8 @@ class WebpackFavicons {
       pixel_art: false,                         // Keeps pixels "sharp" when scaling up, for pixel art. Only supported in offline mode.
       loadManifestWithCredentials: false,       // Browsers don't send cookies when fetching a manifest, enable this to fix that. `boolean`
       icons: { favicons: true },                // Specify which icons to generate
+      manifestPathPattern: '[filename]',        // Manifest file's icon path pattern (default is relative)
+      browserconfigPathPattern: '[filename]',   // Browserconfig file'ss icon path pattern (default is relative)
       ...options,
     };
 
@@ -76,6 +112,23 @@ class WebpackFavicons {
               // Check/Run plugin callback
               if (typeof this.callback === 'function') {
                 response = { ...response, ...this.callback(response) };
+              }
+
+              if (
+                (this.options.manifestPathPattern || this.options.browserconfigPathPattern) 
+                && response.files
+              ) {
+                response.files.forEach(file => {
+                  // favicons npm module does not write paths correctly to manifest file, this is their own issue but we can fix it.
+                  if (file.name === 'manifest.webmanifest') {
+                    file = fixManifestIconSrc(this.options.manifestPathPattern, file);
+                  }
+
+                  // favicons npm module does not write paths correctly to browserconfig file, this is their own issue but we can fix it.
+                  if (file.name === 'browserconfig.xml') {
+                    file = fixBrowserconfigSrc(this.options.browserconfigPathPattern, file);
+                  }
+                });
               }
 
               // Inject generated favicon tags into HTML files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpack-favicons",
-  "version": "1.5.4",
+  "version": "1.5.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpack-favicons",
-      "version": "1.5.4",
+      "version": "1.5.43",
       "license": "MIT",
       "dependencies": {
         "favicons": "7.2.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webpack html favicon",
     "webpack favicons"
   ],
-  "version": "1.5.4",
+  "version": "1.5.43",
   "description": "Webpack plugin to generate favicons for devices and browsers",
   "repository": "drolsen/webpack-favicons",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
   "author": "Devin R. Olsen <devin@devinrolsen.com> (http://devinrolsen.com)",
   "license": "MIT",
   "scripts": {
-    "test": "npm run basic-test && npm run nested-test && npm run public-test && npm run mixed-test && npm run minimal-test && npm run callback-test && npm run copy-test && npm run hybrid-test && npm run full-test && npm run ava-test",
+    "test": "npm run basic-test && npm run nested-test && npm run manifest-test && npm run public-test && npm run mixed-test && npm run minimal-test && npm run callback-test && npm run copy-test && npm run hybrid-test && npm run full-test && npm run ava-test",
     "basic-test": "webpack --config ./test/basic.config.js --mode production",
     "nested-test": "webpack --config ./test/nested.config.js --mode production",
     "public-test": "webpack --config ./test/public-path.config.js --mode production",
+    "manifest-test": "webpack --config ./test/manifest-path.config.js --mode production",
     "mixed-test": "webpack --config ./test/mixed-path.config.js --mode production",
     "full-test": "webpack --config ./test/full.config.js --mode production",
     "callback-test": "webpack --config ./test/callback.config.js --mode production",

--- a/test/ava.test.js
+++ b/test/ava.test.js
@@ -34,6 +34,20 @@ test('recursive-test (ensures output folder(s) gets recursivly created)', t => {
   }
 });
 
+test('manifest-path-test (ensures paths to icons from manifest are correct)', t => {
+  let publicPathTest = false;
+  const testData = fs.readFileSync(path.resolve(__dirname, '../dist/public/test.html'), 'utf8');
+  if (testData.toString().indexOf('href="/build/') !== -1) {
+    publicPathTest = true;
+  }
+
+  //if (publicPathTest) {
+    t.pass();
+  //} else {
+  //  t.fail();
+  //}
+});
+
 test('public-path-test (ensures output.publicPath accounted for)', t => {
   let publicPathTest = false;
   const testData = fs.readFileSync(path.resolve(__dirname, '../dist/public/test.html'), 'utf8');

--- a/test/ava.test.js
+++ b/test/ava.test.js
@@ -35,17 +35,78 @@ test('recursive-test (ensures output folder(s) gets recursivly created)', t => {
 });
 
 test('manifest-path-test (ensures paths to icons from manifest are correct)', t => {
-  let publicPathTest = false;
-  const testData = fs.readFileSync(path.resolve(__dirname, '../dist/public/test.html'), 'utf8');
-  if (testData.toString().indexOf('href="/build/') !== -1) {
-    publicPathTest = true;
+  let testAPassed = false;
+  let testBPassed = false;
+  let testCPassed = false;
+  let testDPassed = false;
+  let testEPassed = false;
+
+  const testADataFile2 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsA/browserconfig.xml'), 'utf8');
+  const testADataFile1 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsA/manifest.webmanifest'), 'utf8');
+  const testADataFile3 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsA/yandex-browser-manifest.json'), 'utf8');
+  
+  const testBDataFile2 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsB/browserconfig.xml'), 'utf8');
+  const testBDataFile1 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsB/manifest.webmanifest'), 'utf8');
+  const testBDataFile3 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsB/yandex-browser-manifest.json'), 'utf8');
+  
+  const testCDataFile2 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsC/browserconfig.xml'), 'utf8');
+  const testCDataFile1 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsC/manifest.webmanifest'), 'utf8');
+  const testCDataFile3 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsC/yandex-browser-manifest.json'), 'utf8');
+  
+  const testDDataFile2 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsD/browserconfig.xml'), 'utf8');
+  const testDDataFile1 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsD/manifest.webmanifest'), 'utf8');
+  const testDDataFile3 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsD/yandex-browser-manifest.json'), 'utf8');
+  
+  const testEDataFile2 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsE/browserconfig.xml'), 'utf8');
+  const testEDataFile1 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsE/manifest.webmanifest'), 'utf8');
+  const testEDataFile3 = fs.readFileSync(path.resolve(__dirname, '../dist/manifest/build/faviconsE/yandex-browser-manifest.json'), 'utf8');
+  
+
+  if (
+    testADataFile1.toString().indexOf('/some/crazy/path/') === -1
+    && testADataFile2.toString().indexOf('/some/crazy/path/') === -1
+    && testADataFile3.toString().indexOf('/some/crazy/path/') === -1
+  ) {
+    testAPassed = true;
   }
 
-  //if (publicPathTest) {
+  if (
+    testBDataFile1.toString().indexOf('/some/crazy/path/') !== -1
+    && testBDataFile2.toString().indexOf('/some/crazy/path/') === -1
+    && testBDataFile3.toString().indexOf('/some/crazy/path/') === -1
+  ) {
+    testBPassed = true;
+  }
+
+  if (
+    testCDataFile1.toString().indexOf('/some/crazy/path/') === -1
+    && testCDataFile2.toString().indexOf('/some/crazy/path/') !== -1
+    && testCDataFile3.toString().indexOf('/some/crazy/path/') === -1
+  ) {
+    testCPassed = true;
+  }
+
+  if (
+    testDDataFile1.toString().indexOf('/some/crazy/path/') === -1
+    && testDDataFile2.toString().indexOf('/some/crazy/path/') === -1
+    && testDDataFile3.toString().indexOf('/some/crazy/path/') !== -1
+  ) {
+    testDPassed = true;
+  }
+
+  if (
+    testEDataFile1.toString().indexOf('/some/crazy/path/') !== -1
+    && testEDataFile2.toString().indexOf('/some/crazy/path/') !== -1
+    && testEDataFile3.toString().indexOf('/some/crazy/path/') !== -1
+  ) {
+    testEPassed = true;
+  }
+
+  if (testAPassed && testBPassed && testCPassed && testDPassed && testEPassed) {
     t.pass();
-  //} else {
-  //  t.fail();
-  //}
+  } else {
+    t.fail();
+  }
 });
 
 test('public-path-test (ensures output.publicPath accounted for)', t => {

--- a/test/manifest-path.config.js
+++ b/test/manifest-path.config.js
@@ -53,7 +53,10 @@ module.exports = {
       theme_color: '#fff',
       icons: {
         android: true,
+        appleIcon: true,
+        appleStartup: true,
         favicons: true,
+        yandex: true,
         windows: true
       }
     }),
@@ -68,7 +71,10 @@ module.exports = {
       manifestPathPattern: '/some/crazy/path/[filename]',
       icons: {
         android: true,
+        appleIcon: true,
+        appleStartup: true,
         favicons: true,
+        yandex: true,
         windows: true
       }
     }),
@@ -83,11 +89,14 @@ module.exports = {
       browserconfigPathPattern: '/some/crazy/path/[filename]',
       icons: {
         android: true,
+        appleIcon: true,
+        appleStartup: true,
         favicons: true,
+        yandex: true,
         windows: true
       }
     }),
-    /* Both manifest and browser config pathing */
+    /* Yanderx Manifest only pathing */
     new WebpackFavicons({
       appName: 'Webpack Favicons',
       appDescription: 'Webpack Favicons for Webpack 5',
@@ -95,14 +104,36 @@ module.exports = {
       path: 'faviconsD',
       background: '#fff',
       theme_color: '#fff',
-      manifestPathPattern: '/some/crazy/path/[filename]',
-      browserconfigPathPattern: '/some/crazy/path/[filename]',
+      yandexManifestIconPattern: '/some/crazy/path/[filename]',
       icons: {
         android: true,
+        appleIcon: true,
+        appleStartup: true,
         favicons: true,
+        yandex: true,
         windows: true
       }
-    }) 
+    }),
+    /* All manifest and config pathing */
+    new WebpackFavicons({
+      appName: 'Webpack Favicons',
+      appDescription: 'Webpack Favicons for Webpack 5',
+      src: 'assets/favicon.svg',
+      path: 'faviconsE',
+      background: '#fff',
+      theme_color: '#fff',
+      manifestPathPattern: '/some/crazy/path/[filename]',
+      browserconfigPathPattern: '/some/crazy/path/[filename]',
+      yandexManifestIconPattern: '/some/crazy/path/[filename]',
+      icons: {
+        android: true,
+        appleIcon: true,
+        appleStartup: true,
+        favicons: true,
+        yandex: true,
+        windows: true
+      }
+    })  
   ]
 };
 

--- a/test/manifest-path.config.js
+++ b/test/manifest-path.config.js
@@ -1,0 +1,108 @@
+const WebpackFavicons = require('../index.js');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+
+module.exports = {
+  entry: path.resolve(__dirname, 'test.js'),
+  output: {
+    path: path.resolve(__dirname, '../dist/manifest/build'), 
+    publicPath: '/build',
+    filename: 'test.js',
+    pathinfo: false
+  },
+  module: {
+    rules: [{
+      test: /\.html$/,
+      exclude: /node_modules/,
+      include: [
+        path.resolve(__dirname, 'test.html')
+      ],
+      use: {
+        loader: 'html-loader', // (see: https://www.npmjs.com/package/html-loader)
+        options: { minimize: false }
+      }
+    }]
+  },
+  devtool: false,
+  optimization: {
+    minimize: false
+  },
+  stats: 'none',
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../node_modules/.cache/WebpackFavicons/manifestPath'),
+    buildDependencies: {
+      config: [__filename] // Invalidate cache if config changes
+    },
+  },    
+  plugins: [
+    new HtmlWebpackPlugin({
+      title: 'Public Path Test',
+      template: './test/test.html',
+      filename: './test.html',
+      minify: false
+    }),
+    /* Default */
+    new WebpackFavicons({
+      appName: 'Webpack Favicons',
+      appDescription: 'Webpack Favicons for Webpack 5',
+      src: 'assets/favicon.svg',
+      path: 'faviconsA',
+      background: '#fff',
+      theme_color: '#fff',
+      icons: {
+        android: true,
+        favicons: true,
+        windows: true
+      }
+    }),
+    /* Manifest only pathing */
+    new WebpackFavicons({
+      appName: 'Webpack Favicons',
+      appDescription: 'Webpack Favicons for Webpack 5',
+      src: 'assets/favicon.svg',
+      path: 'faviconsB',
+      background: '#fff',
+      theme_color: '#fff',
+      manifestPathPattern: '/some/crazy/path/[filename]',
+      icons: {
+        android: true,
+        favicons: true,
+        windows: true
+      }
+    }),
+    /* Browser config only pathing */
+    new WebpackFavicons({
+      appName: 'Webpack Favicons',
+      appDescription: 'Webpack Favicons for Webpack 5',
+      src: 'assets/favicon.svg',
+      path: 'faviconsC',
+      background: '#fff',
+      theme_color: '#fff',
+      browserconfigPathPattern: '/some/crazy/path/[filename]',
+      icons: {
+        android: true,
+        favicons: true,
+        windows: true
+      }
+    }),
+    /* Both manifest and browser config pathing */
+    new WebpackFavicons({
+      appName: 'Webpack Favicons',
+      appDescription: 'Webpack Favicons for Webpack 5',
+      src: 'assets/favicon.svg',
+      path: 'faviconsD',
+      background: '#fff',
+      theme_color: '#fff',
+      manifestPathPattern: '/some/crazy/path/[filename]',
+      browserconfigPathPattern: '/some/crazy/path/[filename]',
+      icons: {
+        android: true,
+        favicons: true,
+        windows: true
+      }
+    }) 
+  ]
+};
+


### PR DESCRIPTION
Out of the box itgalaxy/favicons has issues with producing relative paths within manifest or browserconfig files.
This both fixes that for them and offers end users her a way to define custom path patterns using three new options:

Option | Type | Description
--- | --- | ---
`manifestPathPattern` | String | Defines a custom path for this file's icon path. Default is `[filename]` which makes relative paths.
`browserconfigPathPattern` | String | Defines a custom path for this file's icon path. Default is `[filename]` which makes relative paths.
`yandexManifestIconPattern` | String | Defines a custom path for this file's icon path. Default is `[filename]` which makes relative paths.

#27 